### PR TITLE
Adding maps package

### DIFF
--- a/v1/maps/maps.go
+++ b/v1/maps/maps.go
@@ -1,0 +1,10 @@
+package maps
+
+// Copy makes a shallow copy of a map
+func Copy[K comparable, V any](m map[K]V) map[K]V {
+	d := make(map[K]V)
+	for k, v := range m {
+		d[k] = v
+	}
+	return d
+}

--- a/v1/maps/maps_test.go
+++ b/v1/maps/maps_test.go
@@ -1,0 +1,23 @@
+package maps
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCopy(t *testing.T) {
+	tests := []struct {
+		Input  map[int]string
+		Output map[int]string
+	}{
+		{
+			map[int]string{1: "One", 2: "Two"},
+			map[int]string{1: "One", 2: "Two"},
+		},
+	}
+
+	for _, e := range tests {
+		assert.Equal(t, e.Output, Copy(e.Input))
+	}
+}


### PR DESCRIPTION
This adds one new utility function which makes a shallow copy of a map: `maps.Copy`.